### PR TITLE
feat: Add atuin

### DIFF
--- a/Containerfile.zeliblue-cli
+++ b/Containerfile.zeliblue-cli
@@ -23,4 +23,7 @@ RUN curl -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases
 RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/bin
 
 # Atuin
-RUN bash <(curl https://raw.githubusercontent.com/atuinsh/atuin/main/install.sh)
+RUN curl -Lo /tmp/atuin.tar.gz "https://github.com/atuinsh/atuin/releases/download/v18.0.2/atuin-v18.0.2-x86_64-unknown-linux-gnu.tar.gz" && \
+    tar -xzf /tmp/atuin.tar.gz -C /tmp && \
+    install -c -m 0755 /tmp/atuin /usr/bin && \
+    rm /tmp/*

--- a/Containerfile.zeliblue-cli
+++ b/Containerfile.zeliblue-cli
@@ -25,5 +25,5 @@ RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/bin
 # Atuin
 RUN curl -Lo /tmp/atuin.tar.gz "https://github.com/atuinsh/atuin/releases/download/v18.0.2/atuin-v18.0.2-x86_64-unknown-linux-gnu.tar.gz" && \
     tar -xzf /tmp/atuin.tar.gz -C /tmp && \
-    install -c -m 0755 /tmp/atuin /usr/bin && \
+    install -c -m 0755 /tmp/atuin-v18.0.2-x86_64-unknown-linux-gnu/atuin /usr/bin && \
     rm /tmp/*

--- a/Containerfile.zeliblue-cli
+++ b/Containerfile.zeliblue-cli
@@ -21,3 +21,6 @@ RUN curl -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases
 
 # Chezmoi
 RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/bin
+
+# Atuin
+RUN bash <(curl https://raw.githubusercontent.com/atuinsh/atuin/main/install.sh)

--- a/Containerfile.zeliblue-cli
+++ b/Containerfile.zeliblue-cli
@@ -26,4 +26,4 @@ RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/bin
 RUN curl -Lo /tmp/atuin.tar.gz "https://github.com/atuinsh/atuin/releases/download/v18.0.2/atuin-v18.0.2-x86_64-unknown-linux-gnu.tar.gz" && \
     tar -xzf /tmp/atuin.tar.gz -C /tmp && \
     install -c -m 0755 /tmp/atuin-v18.0.2-x86_64-unknown-linux-gnu/atuin /usr/bin && \
-    rm /tmp/*
+    rm -r /tmp/atuin-v18.0.2-x86_64-unknown-linux-gnu

--- a/files/usr/share/fish/vendor_conf.d/bling.fish
+++ b/files/usr/share/fish/vendor_conf.d/bling.fish
@@ -1,5 +1,6 @@
 if status is-interactive
     # set -gx STARSHIP_CONFIG /etc/starship.toml
+    atuin init fish | source
     starship init fish | source
     zoxide init --cmd cd fish | source
     # set -gx HOST (hostname -s)


### PR DESCRIPTION
Installs atuin manually in a similar manner as the starship prompt. The downside is, due to how the folder names are with atuin's releases, we can't easily just keep it pointed at latest like starship is, so we'll have to manually keep up with updates.

Also enables atuin for the fish shell, though not for bash due to needing an extra dependency of either ble.sh or bash-preexec.

Closes #2